### PR TITLE
feat: Add Unpack methods for tuples #1

### DIFF
--- a/tuple.go
+++ b/tuple.go
@@ -43,6 +43,11 @@ func (v Pair[_, _]) Get(i int) any {
 	return nil
 }
 
+// Unpack returns the elements of the pair as a tuple.
+func (v Pair[T0, T1]) Unpack() (T0, T1) {
+	return v.First, v.Second
+}
+
 // Triple is a generic type for a triple of values.
 type Triple[T0, T1, T2 any] struct {
 	First  T0
@@ -75,6 +80,11 @@ func (t Triple[_, _, _]) Get(i int) any {
 		return t.Third
 	}
 	return nil
+}
+
+// Unpack returns the elements of the triple as a tuple.
+func (v Triple[T0, T1, T2]) Unpack() (T0, T1, T2) {
+	return v.First, v.Second, v.Third
 }
 
 // Quadruple is a generic type for a quadruple of values.
@@ -112,6 +122,11 @@ func (q Quadruple[_, _, _, _]) Get(i int) any {
 		return q.Fourth
 	}
 	return nil
+}
+
+// Unpack returns the elements of the quadruple as a tuple.
+func (v Quadruple[T0, T1, T2, T3]) Unpack() (T0, T1, T2, T3) {
+	return v.First, v.Second, v.Third, v.Fourth
 }
 
 // Quintuple is a generic type for a quintuple of values.
@@ -152,4 +167,9 @@ func (q Quintuple[_, _, _, _, _]) Get(i int) any {
 		return q.Fifth
 	}
 	return nil
+}
+
+// Unpack returns the elements of the quintuple as a tuple.
+func (v Quintuple[T0, T1, T2, T3, T4]) Unpack() (T0, T1, T2, T3, T4) {
+	return v.First, v.Second, v.Third, v.Fourth, v.Fifth
 }

--- a/tuple_test.go
+++ b/tuple_test.go
@@ -84,6 +84,27 @@ func TestPair(t *testing.T) {
 			t.Errorf("Out of bounds element should be a zero value, got %v", v)
 		}
 	})
+
+	t.Run("Unpack", func(t *testing.T) {
+		pair := tuple.MakePair(10, "hello")
+		first, second := pair.Unpack()
+		if first != 10 {
+			t.Errorf("expected first element to be 10, got %v", first)
+		}
+		if second != "hello" {
+			t.Errorf("expected second element to be \"hello\", got %v", second)
+		}
+
+		// Test with different types
+		pair2 := tuple.MakePair(3.14, true)
+		first2, second2 := pair2.Unpack()
+		if first2 != 3.14 {
+			t.Errorf("expected first element to be 3.14, got %v", first2)
+		}
+		if second2 != true {
+			t.Errorf("expected second element to be true, got %v", second2)
+		}
+	})
 }
 
 func TestTriple(t *testing.T) {
@@ -140,6 +161,20 @@ func TestTriple(t *testing.T) {
 		}
 		if v, ok := triple.Get(3).(int); v != 0 || ok {
 			t.Errorf("Out of bounds element should be a zero value, got %v", v)
+		}
+	})
+
+	t.Run("Triple_Unpack", func(t *testing.T) {
+		triple := tuple.MakeTriple(1, "hello", 3.14)
+		first, second, third := triple.Unpack()
+		if first != 1 {
+			t.Errorf("expected first element to be 1, got %v", first)
+		}
+		if second != "hello" {
+			t.Errorf("expected second element to be \"hello\", got %v", second)
+		}
+		if third != 3.14 {
+			t.Errorf("expected third element to be 3.14, got %v", third)
 		}
 	})
 }
@@ -210,6 +245,23 @@ func TestQuadruple(t *testing.T) {
 		}
 		if v, ok := quadruple.Get(4).(int); v != 0 || ok {
 			t.Errorf("Out of bounds element should be a zero value, got %v", v)
+		}
+	})
+
+	t.Run("Quadruple_Unpack", func(t *testing.T) {
+		quadruple := tuple.MakeQuadruple(1, "hello", 3.14, true)
+		first, second, third, fourth := quadruple.Unpack()
+		if first != 1 {
+			t.Errorf("expected first element to be 1, got %v", first)
+		}
+		if second != "hello" {
+			t.Errorf("expected second element to be \"hello\", got %v", second)
+		}
+		if third != 3.14 {
+			t.Errorf("expected third element to be 3.14, got %v", third)
+		}
+		if fourth != true {
+			t.Errorf("expected fourth element to be true, got %v", fourth)
 		}
 	})
 }
@@ -292,6 +344,26 @@ func TestQuintuple(t *testing.T) {
 		}
 		if v, ok := quintuple.Get(5).(int); v != 0 || ok {
 			t.Errorf("Out of bounds element should be a zero value, got %v", v)
+		}
+	})
+
+	t.Run("Quintuple_Unpack", func(t *testing.T) {
+		quintuple := tuple.MakeQuintuple(1, "hello", 3.14, true, 'a')
+		first, second, third, fourth, fifth := quintuple.Unpack()
+		if first != 1 {
+			t.Errorf("expected first element to be 1, got %v", first)
+		}
+		if second != "hello" {
+			t.Errorf("expected second element to be \"hello\", got %v", second)
+		}
+		if third != 3.14 {
+			t.Errorf("expected third element to be 3.14, got %v", third)
+		}
+		if fourth != true {
+			t.Errorf("expected fourth element to be true, got %v", fourth)
+		}
+		if fifth != 'a' {
+			t.Errorf("expected fifth element to be 'a', got %v", fifth)
 		}
 	})
 }


### PR DESCRIPTION
Added `Unpack` methods to `Pair`, `Triple`, `Quadruple`, and `Quintuple` to allow easy access to individual elements as separate variables. This enhances usability and readability when working with tuples. Includes corresponding unit tests to verify functionality.