### PR TITLE
Add link to v1 docs and remove broken Go Report Card badge from v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!INFO]
+> [!NOTE]
 > [README for v1](README.v1.md)
 
 # goaux/tuple v2

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!INFO]
+> [README for v1](README.v1.md)
+
 # goaux/tuple v2
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/goaux/tuple/v2.svg)](https://pkg.go.dev/github.com/goaux/tuple/v2)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # goaux/tuple v2
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/goaux/tuple/v2.svg)](https://pkg.go.dev/github.com/goaux/tuple/v2)
-[![Go Report Card](https://goreportcard.com/badge/github.com/goaux/tuple/v2)](https://goreportcard.com/report/github.com/goaux/tuple/v2)
+<!-- [![Go Report Card](https://goreportcard.com/badge/github.com/goaux/tuple/v2)](https://goreportcard.com/report/github.com/goaux/tuple/v2) -->
 
 A tiny, compile‑time‑safe library that gives you a **generic tuple** type for every size from 2 up to 32 values.
 The package is split into a separate sub‑package per tuple length so you only import what you need – no unnecessary dependencies or large monolithic packages.

--- a/v2/README.md
+++ b/v2/README.md
@@ -1,7 +1,7 @@
 # goaux/tuple v2
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/goaux/tuple/v2.svg)](https://pkg.go.dev/github.com/goaux/tuple/v2)
-[![Go Report Card](https://goreportcard.com/badge/github.com/goaux/tuple/v2)](https://goreportcard.com/report/github.com/goaux/tuple/v2)
+<!-- [![Go Report Card](https://goreportcard.com/badge/github.com/goaux/tuple/v2)](https://goreportcard.com/report/github.com/goaux/tuple/v2) -->
 
 A tiny, compile‑time‑safe library that gives you a **generic tuple** type for every size from 2 up to 32 values.
 The package is split into a separate sub‑package per tuple length so you only import what you need – no unnecessary dependencies or large monolithic packages.


### PR DESCRIPTION
A quick informational link to the legacy v1 documentation is also added. Once the underlying issue is fixed, the badges can be restored.

The new `v2` layout broke the Go Report Card check, so we temporarily comment out the badge links in both `README.md` and `v2/README.md`.